### PR TITLE
Update live demo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,38 @@
 # Alpha leaks demo
 
-See the live demo [here](https://manumonti.github.io/alpha-leaks-demo/).
+See the live demo [here](https://nucypher.github.io/alpha-leaks-demo/).
 
 This is a demo that illustrates a use case of [Nucypher's Conditions-Based
 Decryption](https://docs.threshold.network/app-development/threshold-access-control-tac/get-started-with-tac).
 
-This is a weblog. There are three levels of subscription. Each subscription level will let you access the posts corresponding to your subscription. Subscription levels are defined by the balance of MultiFaucet NFTs your account owns.
+This is a weblog. There are three levels of subscription. Each subscription level will let you
+access the posts corresponding to your subscription. Subscription levels are defined by the balance
+of MultiFaucet NFTs your account owns.
 
-![](https://placehold.co/15x1/peru/peru.png) Bronze subscription will let you read only the Bronze posts. **One NFT is needed.**
+![](https://placehold.co/15x1/peru/peru.png) Bronze subscription will let you read only the Bronze
+posts. **One NFT is needed.**
 
-![](https://placehold.co/15x15/silver/silver.png) Silver subscription will let you read Bronze and Silver posts. **Two NFTs are needed.**
+![](https://placehold.co/15x15/silver/silver.png) Silver subscription will let you read Bronze and
+Silver posts. **Two NFTs are needed.**
 
-![](https://placehold.co/15x15/gold/gold.png) Gold subscription will let you read Bronze, Silver, and Gold posts. **Three NFTs are needed.**
+![](https://placehold.co/15x15/gold/gold.png) Gold subscription will let you read Bronze, Silver,
+and Gold posts. **Three NFTs are needed.**
 
-The decryption of the posts is done by Nucypher's CBD technology. CBD will check the balance of NFTs and show you the corresponding blog posts.
+The decryption of the posts is done by Nucypher's CBD technology. CBD will check the balance of NFTs
+and show you the corresponding blog posts.
 
 ## Usage
 
-To run this demo you will need to have MetaMask installed and an account with sufficient MATIC on Polygon Mumbai testnet to fund the "Create Policy" contract method call.
+To run this demo you will need to have MetaMask installed and an account with sufficient MATIC on
+Polygon Mumbai testnet to fund the "Create Policy" contract method call.
 
-Additionally, to have decryption rights over the posts, you will need a number of [MultiFaucet NFTs](https://mumbai.polygonscan.com/address/0xf5de760f2e916647fd766b4ad9e85ff943ce3a2b#code) on Polygon Mumbai testnet. The balance of this ERC721 token will determine the subscription level and, therefore, the number of posts you will be able to see.
+Additionally, to have decryption rights over the posts, you will need a number of [MultiFaucet
+NFTs](https://mumbai.polygonscan.com/address/0xf5de760f2e916647fd766b4ad9e85ff943ce3a2b#code) on
+Polygon Mumbai testnet. The balance of this ERC721 token will determine the subscription level and,
+therefore, the number of posts you will be able to see.
 
-Both, MATIC and MultiFaucet NFTs can be claimed in [Paradigm MultiFaucet](https://faucet.paradigm.xyz/).
+Both, MATIC and MultiFaucet NFTs can be claimed in [Paradigm
+MultiFaucet](https://faucet.paradigm.xyz/).
 
 
 ## Installation

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "alpha-leaks-demo",
   "version": "0.1.0",
   "private": true,
-  "homepage": "https://manumonti.github.io/alpha-leaks-demo/",
+  "homepage": "https://nucypher.github.io/alpha-leaks-demo/",
   "engines": {
     "node": ">=16"
   },  "scripts": {

--- a/src/index.html
+++ b/src/index.html
@@ -7,7 +7,7 @@
     <link rel="shortcut icon" href="" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="Alpha leaks demo is based on Nucypher's CBD technology"
     />
     <title>Alpha leaks demo</title>
   </head>


### PR DESCRIPTION
Since the repo has been migrated to Nucypher organization recently, the URL for live demo, supported by Github Pages, has changed.