### PR TITLE
Add "No Posts" message when no decrypted posts

### DIFF
--- a/src/components/Blog/Post.tsx
+++ b/src/components/Blog/Post.tsx
@@ -13,23 +13,13 @@ function Post({ post }: any) {
     return <i style={style}>{color}</i>;
   }
 
-  if (Object.keys(post).length === 0) {
-    return (
-      <div className="post-container">
-        <h2 className="post-heading">No articles available</h2>
-      </div>
-    );
-  }
-
   return (
     <div className="post-container">
       {colorTier(post.tier)}
       <h2 className="post-heading">{post.title}</h2>
       <img className="post-image" src={post.imgUrl} />
       <p>{post.body}</p>
-      <div className="info">
-        <h4>Written by: {post.author}</h4>
-      </div>
+      <h4>Written by: {post.author}</h4>
     </div>
   );
 }

--- a/src/components/Blog/Posts.tsx
+++ b/src/components/Blog/Posts.tsx
@@ -9,6 +9,15 @@ function Posts({ decryptedMessages }: any) {
     blogPosts = JSON.parse(decryptedMessages);
   }
 
+  if (blogPosts.length === 0) {
+    return (
+      <div className="post-container">
+        <h2 className="post-heading">No posts available</h2>
+        <h4>You need some <a href="https://faucet.paradigm.xyz/">MultiFaucet NFTs</a> to decrypt the posts.</h4>
+      </div>
+    );
+  }
+
   return (
     <div className="posts-container">
       {blogPosts.map((post, index) => (


### PR DESCRIPTION
This PR fixes #3

> When the selected MetaMask account doesn't comply with any condition (bronze, silver, gold), no message is shown in the application. This can be confusing to the user, who doesn't have any feedback about what is happening. The user doesn't know if there are no posts, the account doesn't comply with the conditions, or he/she should wait a little bit more.