### PR TITLE
Make decryption status on header more insightful

### DIFF
--- a/src/components/CBD/CBDHeader.tsx
+++ b/src/components/CBD/CBDHeader.tsx
@@ -10,6 +10,7 @@ function CBDHeader({ decryptedMessages, setDecryptedMessages }: any) {
   const [depStrategyStatus, setDepStrategyStatus] = useState("not deployed");
   const [conditionSets, setConditionSets] = useState([]);
   const [encryptedMessages, setEncryptedMessages] = useState([]);
+  const [decMessagesStatus, setDecMessagesStatus] = useState("not decrypted");
   const { activateBrowserWallet, deactivate, account } = useEthers();
 
   function shortenAddress(address: string | undefined) {
@@ -21,10 +22,6 @@ function CBDHeader({ decryptedMessages, setDecryptedMessages }: any) {
 
   function showEncrypted() {
     return encryptedMessages.length !== 0 ? "encrypted" : "not ready";
-  }
-
-  function showDecrypted() {
-    return decryptedMessages.length !== 0 ? "decrypted" : "not ready";
   }
 
   return (
@@ -55,6 +52,7 @@ function CBDHeader({ decryptedMessages, setDecryptedMessages }: any) {
               conditionSets={conditionSets}
               encryptedMessages={encryptedMessages}
               setDecryptedMessages={setDecryptedMessages}
+              setDecMessagesStatus={setDecMessagesStatus}
             />
           </div>
         </div>
@@ -75,7 +73,7 @@ function CBDHeader({ decryptedMessages, setDecryptedMessages }: any) {
               Posts encryption: <b>{showEncrypted()}</b>
             </div>
             <div>
-              Posts decryption: <b>{showDecrypted()}</b>
+              Posts decryption: <b>{decMessagesStatus}</b>
             </div>
           </div>
         </div>

--- a/src/components/CBD/Decrypt.tsx
+++ b/src/components/CBD/Decrypt.tsx
@@ -9,11 +9,13 @@ function Decrypt({
   conditionSets,
   encryptedMessages,
   setDecryptedMessages,
+  setDecMessagesStatus,
 }: any) {
   const decrypt = async () => {
     if (!depStrategy.decrypter) return;
 
     setDecryptedMessages([]);
+    setDecMessagesStatus("decrypting...");
 
     let blogPosts: Object[] = [];
     const web3Provider = new providers.Web3Provider(window.ethereum);
@@ -46,6 +48,7 @@ function Decrypt({
     }
 
     setDecryptedMessages(JSON.stringify(blogPosts));
+    setDecMessagesStatus("decrypted")
   };
 
   return (


### PR DESCRIPTION
Up to now, the decryption status shown on the header only has two values: not ready and decrypted.

This may be confusing to the user since the decryption process time (several seconds) can be understood as an error.

With this change, a new value "decrypting..." is added to this status.